### PR TITLE
[Fix] CI/CD 과정 중 TypeScript 컴파일 체크 오류

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -7,6 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
+    "build:check": "tsc --noEmit",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "db:schema": "source .env && mysql -u$DB_USER -p$DB_PASSWORD $DB_NAME < ./src/common/sql/schema.sql",
     "start": "nest start",


### PR DESCRIPTION

## ❓ 어떤 버그인가요?
<img width="669" alt="image" src="https://github.com/user-attachments/assets/4ada0ea8-bb93-41e7-b201-a0657e836aef">

CI/CD중 타입스크립트 검사하는 부분에서 오류가 발생했습니다.
실행 스크립트를 추가안해준 실수였습니다 😭


## 🕘 발생 일시

- 2024년 11월 13일, 오전 10시 30분

## 📝 예상 결과

- git action의 정상적인 동작
