### PR TITLE
[Feat] 마피아 동료 정보 전달방식 변경

### DIFF
--- a/BE/src/game/usecase/allocate-user-role/random.job.factory.ts
+++ b/BE/src/game/usecase/allocate-user-role/random.job.factory.ts
@@ -53,7 +53,7 @@ export class RandomJobFactory implements JobFactory {
     mafiaUsers.forEach(([currentPlayer, currentRole]) => {
       const otherMafias = mafiaUsers
         .filter((player:[GameClient,MAFIA_ROLE]) => player[0] !== currentPlayer)
-        .map(([player, role]) => [player.client.socket.id, role]);
+        .map(([player, role]) => [player.nickname, role]);
 
       currentPlayer.send('player-role', {
         'role': currentRole,


### PR DESCRIPTION
## ☑️ 개발 유형

- [ ] Front-end
- [x] Back-end

## ✔️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.

- [x] 처음 직업이 정해지면 해당 클라이언트에게 직업 정보를 전달하는데 마피아인 경우 동료 마피아 정보까지 전달해야 합니다. 그 때, 동료 마피아의 SocketId 정보를 전달했는데 nickname이 고유하다고 결정해 nickname 정보를 전달하는 방식으로 변경했습니다.

## #️⃣ Related Issue

해당 Pull Request과 관련된 Issue Link를 작성해 주세요
#132 