### PR TITLE
[Fix] openvidu 세션 종료 함수 에러 해결

### DIFF
--- a/BE/src/video-server/implementations/openvidu.service.ts
+++ b/BE/src/video-server/implementations/openvidu.service.ts
@@ -57,9 +57,8 @@ export class OpenviduService implements VideoServerUsecase {
           );
         }
       }
-      await session.close();
       this.sessions.delete(roomId);
-      console.log(`Session ${roomId} successfully closed and cleaned up`);
+      console.log(`Session ${roomId} is closed and cleaned up`);
     } catch (error) {
       console.error(`Failed to close session: ${error.message}`);
       throw new OpenviduSessionCloseFailedException();


### PR DESCRIPTION

## ☑️ 개발 유형

- [ ] Front-end
- [x] Back-end

## ✔️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

게임 종료 시 동작되는 openvidu 세션 종료의 에러를 수정했습니다.
생각보다 간단하게 해결할 수 있었지만, 해당 오류에 대한 확실한 근거는 찾지 못한 상황입니다.

아래 트러블 슈팅 과정이 담긴 링크를 첨부해둡니다.
https://broken-bubble-48c.notion.site/openvidu-145c95a1e2c68043b07cc711d8311ea4?pvs=4



## #️⃣ Related Issue

#187 

