### PR TITLE
[Feat] 특정 단계 카운트 다운 시작 이벤트 추가

### DIFF
--- a/BE/src/game/usecase/countdown/mafia.countdown.timer.ts
+++ b/BE/src/game/usecase/countdown/mafia.countdown.timer.ts
@@ -8,7 +8,6 @@ import { GameRoom } from '../../../game-room/entity/game-room.model';
 
 @Injectable()
 export class MafiaCountdownTimer implements CountdownTimer {
-
   private readonly stopSignals = new Map<GameRoom, Subject<any>>();
   private readonly pauses = new Map<GameRoom, boolean>();
 
@@ -19,30 +18,31 @@ export class MafiaCountdownTimer implements CountdownTimer {
     this.stopSignals.set(room, new Subject());
     this.pauses.set(room, false);
     let timeLeft: number = TIMEOUT_SITUATION[situation];
+
+    room.sendAll('countdown-start', situation);
+
     const currentSignal = this.stopSignals.get(room);
     let paused = this.pauses.get(room);
     return new Promise<void>((resolve) => {
-      interval(1000).pipe(
-        takeUntil(currentSignal),
-        takeWhile(() => timeLeft > 0 && !paused),
-      ).subscribe({
-        next: () => {
-          paused = this.pauses.get(room);
-          room.sendAll('countdown', {
-            situation: situation,
-            timeLeft: timeLeft,
-          });
-          timeLeft--;
-        },
-        complete: () => {
-          room.sendAll('countdown-exit', {
-            situation: situation,
-            timeLeft: timeLeft,
-          });
-          this.stop(room);
-          resolve();
-        },
-      });
+      interval(1000)
+        .pipe(
+          takeUntil(currentSignal),
+          takeWhile(() => timeLeft > 0 && !paused),
+        )
+        .subscribe({
+          next: () => {
+            paused = this.pauses.get(room);
+            room.sendAll('countdown', {
+              situation: situation,
+              timeLeft: timeLeft,
+            });
+            timeLeft--;
+          },
+          complete: () => {
+            this.stop(room);
+            resolve();
+          },
+        });
     });
   }
 
@@ -68,5 +68,4 @@ export class MafiaCountdownTimer implements CountdownTimer {
     this.pause(room);
     this.cleanup(room);
   }
-
 }


### PR DESCRIPTION

## ☑️ 개발 유형

- [ ] Front-end
- [x] Back-end

## ✔️ PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

- 특정 단계 카운트 다운 종료 이벤트를 삭제
- 특정 단계 카운트 다운 시작 이벤트를 추가


## #️⃣ Related Issue

#204 

## 설명
특정 상태에 대한 카운트 다운 시작 이벤트를 제작했습니다.
이전 특정 단계 카운트 다운 종료 이벤트는 불필요하다고 논의가 되어 삭제해두었습니다.

`room.sendAll('countdown-start', situation);` : 특정 상태만 알리면 되는 것이라 간단한 문자열로 응답처리를 할 수 있습니다.