### PR TITLE
[Feat] 웹소켓 커넥션을 연결할 때 헤더에 담긴 토큰으로 유저 정보를 조회하는 기능 구현

### DIFF
--- a/BE/src/event/event-client.model.ts
+++ b/BE/src/event/event-client.model.ts
@@ -4,6 +4,7 @@ import { EventManager, Subscriber, Subscription } from './event-manager';
 export class EventClient {
   private readonly subscriptions: Subscription[] = [];
   private _nickname: string;
+  private _userId: number;
 
   constructor(
     private readonly _socket: Socket,
@@ -16,6 +17,14 @@ export class EventClient {
 
   set nickname(nickname: string) {
     this._nickname = nickname;
+  }
+
+  get userId() {
+    return this._userId;
+  }
+
+  set userId(userId: number) {
+    this._userId = userId;
   }
 
   get socket(): Socket {

--- a/BE/src/event/event.gateway.ts
+++ b/BE/src/event/event.gateway.ts
@@ -5,6 +5,7 @@ import {
   OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
+  WsException,
   WsResponse,
 } from '@nestjs/websockets';
 import { Socket } from 'socket.io';
@@ -33,6 +34,7 @@ import {
   DOCTOR_CURE_USECASE,
   DoctorCureUsecase,
 } from '../game/usecase/role-playing/doctor.cure.usecase';
+import { FIND_USERINFO_USECASE, FindUserInfoUsecase } from 'src/user/usecase/find.user-info.usecase';
 
 // @UseInterceptors(WebsocketLoggerInterceptor)
 @WebSocketGateway({
@@ -56,19 +58,41 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly mafiaKillUseCase: MafiaKillUsecase,
     @Inject(DOCTOR_CURE_USECASE)
     private readonly doctorCureUsecase: DoctorCureUsecase,
+    @Inject(FIND_USERINFO_USECASE)
+    private readonly findUserInfoUsecase: FindUserInfoUsecase,
   ) {}
 
-  handleConnection(socket: Socket) {
-    this.logger.log(`client connected: ${socket.id}`);
+  async handleConnection(socket: Socket) {
+    this.logger.log(`[${socket.id}] Client connected`);
+    const headers = socket.handshake.headers;
+    const token = this.parseToken(headers);
+    if (!token) {
+      this.logger.log(`[${socket.id}] Unauthorized client`);
+      // todo: socket 연결 강제로 끊기
+      return;
+    }
+    const { nickname, userId } = await this.findUserInfoUsecase.find(token);
     const client = new EventClient(socket, this.eventManager);
+    client.nickname = nickname;
+    client.userId = userId;
     client.subscribe(Event.ROOM_DATA_CHANGED);
     this.connectedClients.set(socket, client);
     this.publishRoomDataChangedEvent();
   }
 
+  private parseToken(headers): string {
+    const cookies = headers.cookie?.split(';').map((keyVal) => keyVal.split('=')).reduce((cookies, [key, val]) => {
+      cookies[key.trim()] = val.trim();
+    }, {});
+    return cookies?.access_token;
+  }
+
   handleDisconnect(socket: Socket) {
-    this.logger.log(`client disconnected: ${socket.id}`);
+    this.logger.log(`[${socket.id}] Client disconnected`);
     const client = this.connectedClients.get(socket);
+    if (!client) {
+      return;
+    }
     client.unsubscribeAll();
     this.connectedClients.delete(socket);
   }

--- a/BE/src/event/event.gateway.ts
+++ b/BE/src/event/event.gateway.ts
@@ -83,6 +83,7 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
   private parseToken(headers): string {
     const cookies = headers.cookie?.split(';').map((keyVal) => keyVal.split('=')).reduce((cookies, [key, val]) => {
       cookies[key.trim()] = val.trim();
+      return cookies;
     }, {});
     return cookies?.access_token;
   }

--- a/BE/src/event/event.module.ts
+++ b/BE/src/event/event.module.ts
@@ -3,9 +3,10 @@ import { EventGateway } from './event.gateway';
 import { GameRoomModule } from 'src/game-room/game-room.module';
 import { EventManager } from './event-manager';
 import { GameModule } from 'src/game/game.module';
+import { UserModule } from 'src/user/user.module';
 
 @Module({
-  imports: [GameRoomModule, GameModule,],
+  imports: [GameRoomModule, GameModule, UserModule],
   providers: [EventGateway, EventManager],
 })
 export class EventModule {}

--- a/BE/src/game-room/entity/game-room.model.ts
+++ b/BE/src/game-room/entity/game-room.model.ts
@@ -154,7 +154,8 @@ export class GameRoom {
   }
 
   private delegateOwner() {
-    const nicknames = this._clients.map((c) => c.nickname);
-    return nicknames.sort(() => Math.random() - 0.5).pop();
+    const length = this._clients.length;
+    const randIdx = Math.floor(Math.random() * length);
+    return this._clients[randIdx].nickname;
   }
 }

--- a/BE/src/game/total.game-manager.ts
+++ b/BE/src/game/total.game-manager.ts
@@ -535,6 +535,11 @@ export class TotalGameManager
     return await this.lockManager.withKeyLock(gameRoom.roomId, async () => {
       this.sendResultToClient(gameRoom);
       await this.saveGameResult(gameRoom);
+      const roomId = gameRoom.roomId;
+      this.games.delete(roomId);
+      this.ballotBoxs.delete(roomId);
+      this.mafiaCurrentTarget.delete(roomId);
+      this.mafiaSelectLogs.delete(roomId);
       gameRoom.reset();
     });
   }

--- a/BE/src/user/user.module.ts
+++ b/BE/src/user/user.module.ts
@@ -52,7 +52,7 @@ import { FIND_USERINFO_USECASE } from './usecase/find.user-info.usecase';
       useClass: UserService
     }
   ],
-  exports: [FIND_USER_USECASE, REGISTER_USER_USECASE],
+  exports: [FIND_USER_USECASE, REGISTER_USER_USECASE, FIND_USERINFO_USECASE],
 })
 export class UserModule {
 }

--- a/BE/src/user/user.service.ts
+++ b/BE/src/user/user.service.ts
@@ -130,7 +130,7 @@ export class UserService implements FindUserUsecase, RegisterUserUsecase, LoginU
       throw new NotFoundUserException();
     }
     return {
-      nickname:userEntity.nickname,
+      nickname: userEntity.nickname,
       userId: userId,
     };
   }


### PR DESCRIPTION
## ☑️ 개발 유형

- [ ] Front-end
- [x] Back-end

## ✔️ PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

- [x] 웹소켓 커넥션이 연결될 때 헤더에 있는 토큰으로 유저 정보를 조회해 EventClient에 userId와 nickname을 넣어주도록 구현했습니다.
- [x] 방장을 위임할 사람을 선택할 때 map을 사용하는 대신 인덱스를 랜덤으로 선정해 선택하도록 수정했습니다.
- [x] 게임이 종료될 때 TotalGameManager에 있는 세션을 전부 정리하도록 했습니다. 

## #️⃣ Related Issue

#218 
#221 
