### PR TITLE
[Fix] 이벤트 구독 로직 수정

### DIFF
--- a/BE/src/event/event-manager.ts
+++ b/BE/src/event/event-manager.ts
@@ -21,7 +21,7 @@ export class EventManager {
     if (!subscribers[eventName]) {
       return;
     }
-    subscribers[eventName].forEach((handler) => handler(e));
+    subscribers[eventName].forEach((subscriber) => subscriber(e));
   }
 
   subscribe(eventName: string, handler: Subscriber): Subscription {
@@ -29,11 +29,13 @@ export class EventManager {
     if (!subscribers[eventName]) {
       subscribers[eventName] = [];
     }
-    const index = subscribers[eventName].push(handler) - 1;
+    subscribers[eventName].push(handler);
 
     return {
       unsubscribe() {
-        subscribers[eventName].splice(index, 1);
+        subscribers[eventName] = subscribers[eventName].filter(
+          (subscriber) => subscriber !== handler,
+        );
       },
     };
   }


### PR DESCRIPTION
## ☑️ 개발 유형

- [ ] Front-end
- [x] Back-end

## ✔️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

이벤트 구독 로직을 수정했습니다. 기존에는 이벤트 배열에 함수를 넣는 시점의 배열의 인덱스를 클로저로 관리하며 이벤트를 구독 해제할 때 그 인덱스에 있는 요소를 제거하도록 했습니다. 그랬더니 이벤트를 구독 해제할 때 이벤트 배열에서의 함수의 인덱스가 이벤트를 구독할 당시와 달라지는 문제가 발생했습니다.

예를 들어 이벤트 배열의 구조가 [subscriberA, subscriberB, subscriberC]인 상황에서 subscriberA가 구독을 해제하면 배열이[subscriberB, subscriberC]처럼 바뀌고 이후에 subscriberB가 구독을 해제할 때는 0번 인덱스에 있는 함수를 제거해야하는데 실제로는 이벤트를 구독할 때의 인덱스인 1번 인덱스의 함수를 제거하게 되는 문제가 있어 수정했습니다.

## #️⃣ Related Issue

#262 
