### PR TITLE
[Fix] 게임 재시작 시 마피아 전용 채팅 이벤트 중복 발생 문제 해결

### DIFF
--- a/BE/src/event/event.gateway.ts
+++ b/BE/src/event/event.gateway.ts
@@ -41,6 +41,7 @@ import { MafiaWinState } from '../game/fsm/states/mafia-win.state';
 import { CitizenWinState } from '../game/fsm/states/citizen-win.state';
 import { StopCountdownRequest } from '../game/dto/stop.countdown.request';
 import { GameContextManager } from '../game/fsm/game-context.manager';
+import { MAFIA_ROLE } from 'src/game/mafia-role';
 
 @UseFilters(WebsocketExceptionFilter)
 @UseInterceptors(WebsocketLoggerInterceptor)
@@ -254,7 +255,7 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const room = this.gameRoomService.findRoomById(roomId);
     const client = this.eventClientManager.getClientBySocket(socket);
 
-    room.sendMafia('chat-mafia', {
+    room.sendToRole(MAFIA_ROLE.MAFIA, 'chat-mafia', {
       from: client.nickname,
       to: 'mafia',
       message,

--- a/BE/src/event/event.gateway.ts
+++ b/BE/src/event/event.gateway.ts
@@ -88,7 +88,7 @@ export class EventGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const token = this.parseToken(headers);
     if (!token) {
       this.logger.log(`[${socket.id}] Unauthorized client`);
-      // todo: socket 연결 강제로 끊기
+      socket.disconnect(true);
       return;
     }
     const { nickname, userId } = await this.findUserInfoUsecase.findWs(token);

--- a/BE/src/game-room/entity/game-room.model.ts
+++ b/BE/src/game-room/entity/game-room.model.ts
@@ -16,7 +16,6 @@ export class GameRoom {
   private _createdAt: number = Date.now();
   private _result: GAME_HISTORY_RESULT = null;
   private _clients: GameClient[] = [];
-  private readonly _mafias: GameClient[] = [];
 
   constructor(
     private owner: string,
@@ -111,14 +110,6 @@ export class GameRoom {
 
   sendAll(event: string, ...args) {
     this._clients.forEach((c) => c.send(event, ...args));
-  }
-
-  addMafia(mafia: GameClient) {
-    this._mafias.push(mafia);
-  }
-
-  sendMafia(event: string, ...args) {
-    this._mafias.forEach((m) => m.send(event, ...args));
   }
 
   sendToRole(role: MAFIA_ROLE, event: string, ...args) {

--- a/BE/src/game/total.game-manager.ts
+++ b/BE/src/game/total.game-manager.ts
@@ -74,9 +74,6 @@ export class TotalGameManager
       players.forEach((role, client) => {
         gameInfo.set(client.nickname, { role, status: USER_STATUS.ALIVE });
         client.job = role;
-        if (role === MAFIA_ROLE.MAFIA) {
-          gameRoom.addMafia(client);
-        }
       });
       this.games.set(gameRoom.roomId, gameInfo);
     });


### PR DESCRIPTION
## ☑️ 개발 유형

- [ ] Front-end
- [x] Back-end

## ✔️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 기존 기능에 영향을 주지 않는 변경사항 (Ex. 오타 수정, 탭 사이즈 변경, 변수명 변경, 코드 리팩토링 등)
- [ ] 주석 관련 작업
- [ ] 문서 관련 작업
- [ ] 테스트 추가 혹은 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 작업 내용

- [x] 웹소켓을 연결할 때 인증되지 않은 사용자라면 서버 측에서 강제로 웹소켓 연결을 끊도록 만들었습니다.
- [x] 마피아 전용 채팅 기능을 수정했습니다. 기존에는 GameRoom 객체에서 _mafias라는 배열을 관리하며 sendMafia 메소드를 호출했을 때 _mafias 배열에 있는 클라이언트들에게 메시지를 전송하는 방식이었습니다. 그런데 게임을 종료할 때 이 _mafias 배열이 초기화되지 않아 게임을 다시 시작했을 때 이전 게임에서 마피아를 할당받았던 클라이언트 객체들이 _mafias 배열에 포함되어 있는 문제가 발생했습니다. 이 문제를 해결하기 위한 방법은 두 가지가 있었습니다. 첫 번째는 게임이 종료될 때 _mafias 배열을 초기화하는 것이고, 두 번째는 _mafias 배열을 사용하지 않고 재성님이 만들어두신 sendToRole 메소드를 사용하는 것이었습니다. 두 번째 방식을 선택했습니다.

## #️⃣ Related Issue

#282 
